### PR TITLE
current-callee and current-caller

### DIFF
--- a/runtime.lisp
+++ b/runtime.lisp
@@ -172,7 +172,8 @@
     (.func "decodeURIComponent" (str)
       (with-uri-err (url-encode:url-decode (to-string str) "")))))
 
-(defvar *Function.caller-stack* '(:null :null))
+(defvar *current-caller* :null)
+(defvar *current-callee* :null)
 
 (add-to-lib *stdlib*
   (flet ((defprops (obj props)
@@ -254,7 +255,7 @@
                         (declare (ignore this))
                         (apply proc self (append args args-inner)))
                       (max 0 (- arity (length args))))))
-      (.active-r "caller" (second *Function.caller-stack*)))))
+      (.active-r "caller" *current-caller*))))
 
 (add-to-lib *stdlib*
   (.constructor "Array" (&rest args)

--- a/translate.lisp
+++ b/translate.lisp
@@ -422,9 +422,8 @@
         (when uses-eval
           (push (make-with-scope :var eval-scope) *scope*))
         (let ((body1 `((let* (,@(when *enable-Function.caller*
-                                  `((*Function.caller-stack*
-                                     (cons ,(as-sym fname)
-                                           *Function.caller-stack*))))
+                                 `((*current-caller* *current-callee*)
+                                   (*current-callee* ,(as-sym fname))))
                               ,@(loop :for var :in internal :collect `(,var :undefined))
                               ;; TODO sane object init
                               ,@(and uses-eval `((,eval-scope (make-obj (find-cls :object)))


### PR DESCRIPTION
I benchmarked the two approaches on CCL and SBCL, and using two special variables conses several megabytes less for both ray and codemirror, so I made the change.
