### PR TITLE
Fix Array.prototype.unshift()

### DIFF
--- a/runtime.lisp
+++ b/runtime.lisp
@@ -346,12 +346,17 @@
                   (setf (fill-pointer vec) (1- len))
                   result)
                 :undefined))))
-      (.func "unshift" (val)
+      (.func "unshift" (&rest vals)
         (unless-array 0
-          (let ((vec (aobj-arr this)))
-            (setf (fill-pointer vec) (1+ (length vec)))
-            (replace vec vec :start1 1)
-            (setf (aref vec 0) val)
+          (let* ((vec (aobj-arr this))
+                 (vals-len (length vals))
+                 (new-len (+ (length vec) vals-len)))
+            (if (< new-len (array-dimension vec 0)) 
+                (setf (fill-pointer vec) new-len)
+                (adjust-array vec new-len :fill-pointer new-len))
+            (replace vec vec :start1 vals-len)
+            (loop :for val :in vals :for i :from 0 :do
+               (setf (aref vec i) val))
             (length vec))))
 
       (.func "slice" (from to)

--- a/test.js
+++ b/test.js
@@ -553,6 +553,27 @@ function test_41() {
     $eq(-12 % 7, -5);
 }
 
+function test_42() {
+  var a = [3];
+  $eq(a.unshift(2), 2);
+  $arrEq(a, [2, 3]);
+  $eq(a.unshift(0, 1), 4);
+  $arrEq(a, [0, 1, 2, 3]);
+
+  a = [3, 4];
+  $eq(a.shift(), 3);
+  $arrEq(a, [4]);
+  $eq(a.shift(), 4);
+  $arrEq(a, []);
+  $eq(a.shift(), undefined);
+  $arrEq(a, []);
+
+  $eq(a.unshift(0), 1);
+  $arrEq(a, [0]);
+  $eq(a.unshift(), 1);
+  $arrEq(a, [0]);
+}
+
 function runTests() {
   var failures = [];
   var run = 0;


### PR DESCRIPTION
I found two following issues in Array.prototype.unshift(). 
Then, I fixed them and made the test (test_42).

1. Throw error if the new length is larger than the length of
   the first dimension of the array.
2. Take only one argument and ignore rests.