### PR TITLE
Fix :key/:test typo

### DIFF
--- a/runtime.lisp
+++ b/runtime.lisp
@@ -119,7 +119,7 @@
          (captured-locals (captured-scope-local-vars scope))
          (new-locals (and (not (eq captured-locals :null))
                           (set-difference (find-locals (second parsed)) captured-locals
-                                          :key #'string=))))
+                                          :test #'string=))))
     (declare (special *scope*))
     (dolist (local new-locals) (setf (js-prop env-obj local) :undefined))
     (or (compile-eval (translate-ast parsed)) :undefined)))


### PR DESCRIPTION
#'string= is used as an argument to :key in SET-DIFFERENCE, but :key is for extracting an element, not testing it. Use :test instead.